### PR TITLE
Update setup script for python 3

### DIFF
--- a/setup/1-setup-usr-local.sh
+++ b/setup/1-setup-usr-local.sh
@@ -5,40 +5,38 @@ sudo_message="\nIf prompted for 'password' enter your mac/workstation password\n
 
 if [ "$1" == "nuke" ]; then
     echo -e "\n\n** You have selected the nuke option.  This will delete absolutely everything in /usr/local.  Hit ctrl-c now if this was unintended **\n\n"
-    read -p "Hit enter to continue.  Ctrl-c to exit"
-    echo -e $sudo_message
+    read -rp "Hit enter to continue.  Ctrl-c to exit"
+    echo -e "$sudo_message"
     sudo rm -rf /usr/local/*
 fi
 
-xcode-select -p 1>/dev/null 2>&1 || (xcode-select --install && echo -e "\n\n" && read -rp "Installing xcode command line tools.  Hit enter to continue once it is done")
+(xcode-select --install && echo -e "\n\n" && read -rp "Installing xcode command line tools.  Hit enter to continue once it is done") || true
 
 test -d /usr/local/Homebrew || /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 
-echo -e "\nUpdating permissions, this may take a while..."
-echo -e $sudo_message
+chown_cmd="chown -R $(whoami):admin /usr/local/*"
 
-sudo chown -R $(whoami):admin $(brew --prefix)/*
-sudo chmod 755 /usr/local/share
+$chown_cmd || (echo "At least one file/dir may not be owned by you.  Enter your workstation password if prompted" && sudo $chown_cmd)
 
-if [ ! -d /usr/local/Frameworks ]; then
-    sudo mkdir /usr/local/Frameworks
-fi
+chmod 755 /usr/local/share
+
 if [ ! -d /usr/local/man ]; then
+    echo -e "$sudo_message"
     sudo mkdir /usr/local/man
+    sudo chown "$(whoami):admin" /usr/local/man
 fi
 
-echo -e "\nUpdating Homebrew..."
 brew update
 brew upgrade
 
 while read -r homebrew; do
-    brew install ${homebrew}
-done < ${script_dir}/packages/homebrew.txt
+    brew install "${homebrew}"
+done < "${script_dir}/packages/homebrew.txt"
 
 brew cleanup
 
-pip3 install --upgrade pip
-
-while read -r    pips; do
-    pip3 install ${pips}
-done < ${script_dir}/packages/pip.txt
+# ref /usr/local
+/usr/local/bin/pip3 install --upgrade pip
+while read -r pips; do
+    /usr/local/bin/pip3 install "${pips}"
+done < "${script_dir}/packages/pip.txt"

--- a/setup/2-setup-openbio-virtualenv.sh
+++ b/setup/2-setup-openbio-virtualenv.sh
@@ -5,26 +5,34 @@ ve_name="openbio"
 export PIP_RESPECT_VIRTUALENV=true
 export PIP_VIRTUALENV_BASE=$WORKON_HOME
 export VIRTUALENVWRAPPER_PYTHON=/usr/local/bin/python3
-export VIRTUALENVWRAPPER_VIRTUALENV_ARGS='--no-site-packages'
 export WORKON_HOME=$HOME/.virtualenvs
+unset VIRTUALENVWRAPPER_VIRTUALENV_ARGS
 source virtualenvwrapper.sh
 
-deactivate||echo "Not in a virtualenv"
+deactivate || echo "Not in a virtualenv"
 
 if [ "$1" == "nuke" ]; then
     rmvirtualenv $ve_name
 fi
 
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+pushd "$script_dir" || exit 1
+
+git_dir=$(git rev-parse --show-toplevel)
+pushd "$git_dir" || exit 1
+
 if [ ! -e "$WORKON_HOME/$ve_name/bin/activate" ]; then
-    mkvirtualenv --python=python3 $ve_name
+    mkvirtualenv $ve_name -p python3
+else
+    # always ensure latest python is used in the virtualenv
+    gfind "${WORKON_HOME}/$ve_name/" -type l -xtype l -delete
+    virtualenv -p python3 "${WORKON_HOME}/$ve_name"
 fi
 
 workon $ve_name
 
-script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+pip3 install --upgrade pip
+
 pushd "$script_dir" || exit 1
 
 pip3 install -r ../requirements.txt
-
-grep VIRTUALENVWRAPPER_PYTHON $HOME/.bash_profile || echo "export VIRTUALENVWRAPPER_PYTHON=/usr/local/bin/python3" >> $HOME/.bash_profile
-grep "source virtualenvwrapper.sh" $HOME/.bash_profile || echo "source virtualenvwrapper.sh" >> $HOME/.bash_profile

--- a/setup/3-setup-profile.sh
+++ b/setup/3-setup-profile.sh
@@ -1,0 +1,18 @@
+#! /bin/bash
+
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+if [ -e ~/.bashrc ]; then
+    config_file="$HOME/.bashrc"
+else
+    config_file="$HOME/.bash_profile"
+fi
+ve_rc_file="virtualenvrc"
+
+grep_line='[ -f ~/.virtualenvrc ] && source ~/.virtualenvrc'
+grep -q -F "$grep_line" "$config_file" || echo "$grep_line" >> "$config_file"
+cat "$script_dir/config/$ve_rc_file" > "$HOME/.$ve_rc_file"
+
+echo -e "1) A virtualenv helper script placed at $HOME/.${ve_rc_file} has been ref'd in your ${config_file}.\n"
+echo -e "The point of this script is to automatically activate virtualenvs when you 'cd' to repos with the same name\n"
+echo -e "If you use a shell other than bash, you will need to add/ref the contents of $script_dir/config/$ve_rc_file to your env by your preferred means\n"

--- a/setup/config/virtualenvrc
+++ b/setup/config/virtualenvrc
@@ -1,0 +1,56 @@
+### virtualenv helper
+wrapsource=$(which virtualenvwrapper.sh)
+if [[ -f "$wrapsource" ]]; then
+    export PIP_RESPECT_VIRTUALENV=true
+    export PIP_VIRTUALENV_BASE=$WORKON_HOME
+    if [ -f /usr/local/bin/python3 ]; then
+        export VIRTUALENVWRAPPER_PYTHON=/usr/local/bin/python3
+    elif [ -f /opt/homebrew/bin/python3 ]; then
+        export VIRTUALENVWRAPPER_PYTHON=/opt/homebrew/bin/python3
+    else
+        echo "No modern python.  Giving up"
+        exit 1
+    fi
+    export WORKON_HOME=$HOME/.virtualenvs
+    source $wrapsource
+    if [[ ! $DISABLE_VENV_CD -eq 1 ]]; then
+        # Automatically activate Git projects' virtual environments based on the
+        # directory name of the project. Virtual environment name can be overridden
+        # by placing a .venv file in the project root with a virtualenv name in it
+        function workon_cwd {
+            # Check that this is a Git repo
+            PROJECT_ROOT=$(git rev-parse --show-toplevel 2> /dev/null)
+            if (( $? == 0 )); then
+                # Check for virtualenv name override
+                ENV_NAME=$(basename "$PROJECT_ROOT")
+                if [[ -f "$PROJECT_ROOT/.venv" ]]; then
+                    ENV_NAME=$(cat "$PROJECT_ROOT/.venv")
+                fi
+                # Activate the environment only if it is not already active
+                if [[ "$VIRTUAL_ENV" != "$WORKON_HOME/$ENV_NAME" ]]; then
+                    if [[ -e "$WORKON_HOME/$ENV_NAME/bin/activate" ]]; then
+                        workon "$ENV_NAME" && export CD_VIRTUAL_ENV="$ENV_NAME"
+                    elif [[ -e "$VIRTUAL_ENV" ]]; then
+                        deactivate && unset CD_VIRTUAL_ENV
+                    fi
+                fi
+            elif [ $CD_VIRTUAL_ENV ]; then
+                # We've just left the repo, deactivate the environment
+                # Note: this only happens if the virtualenv was activated automatically
+                deactivate && unset CD_VIRTUAL_ENV
+            fi
+            unset PROJECT_ROOT
+        }
+
+        # New cd function that does the virtualenv magic
+        function cd {
+            builtin cd "$@" && workon_cwd
+        }
+    fi
+    # for newly split windows check for virtualenv on startup
+    workon_cwd
+fi
+
+function mk_ve_cwd () {
+    mkvirtualenv $(basename "$PWD") $@
+}

--- a/setup/packages/homebrew.txt
+++ b/setup/packages/homebrew.txt
@@ -1,3 +1,3 @@
 bash
 git
-python@3
+python

--- a/setup/setup-openbio-workstation.sh
+++ b/setup/setup-openbio-workstation.sh
@@ -10,6 +10,9 @@ $script_dir/1-setup-usr-local.sh $1
 echo -e "\n** Creating / updating virtual environment...\n"
 $script_dir/2-setup-openbio-virtualenv.sh $1
 
+echo -e "\n** Creating / updating profile settings...\n"
+$script_dir/3-setup-profile.sh $1
+
 echo -e "\n---\n"
 echo -e "Your environment was correctly set up!\n"
 echo -e "Now close the terminal window and open a fresh one (so everything is loaded cleanly)\n"


### PR DESCRIPTION
Mostly quality of life updates -- lessons learned etc -- but also fixes for breaking python 3 changes.  

Still assumes `/usr/local` for some paths so not M1 compatible*, but it works entirely as expected on the latest macOS otherwise.

(homebrew on Apple Silicon / M1 installs to `/opt/homebrew` instead of `/usr/local`)